### PR TITLE
Transcoder template handling improvements.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group 'com.wowza.wms.plugin.captions'
-version '1.0.0'
+version '1.1.0'
 
 java {
     toolchain {
@@ -51,8 +51,14 @@ tasks.register('copyDeps', Copy) {
     into layout.buildDirectory.dir("libs")
 }
 
+tasks.register('copyLibsForDocker', Copy) {
+    dependsOn jar, copyDeps
+    from layout.buildDirectory.dir("libs")
+    into layout.projectDirectory.dir("lib")
+}
+
 jar.configure {
-    dependsOn (copyDeps)
+    finalizedBy (copyLibsForDocker)
 }
 
 tasks.withType(Jar).configureEach {
@@ -71,6 +77,10 @@ tasks.withType(Jar).configureEach {
         from files('LICENSE.txt')
     }
     archiveBaseName = 'wse-plugin-' + projectName
+}
+
+clean.configure {
+    delete layout.projectDirectory.dir("lib")
 }
 
 gitProperties {

--- a/conf/azure/Application.xml
+++ b/conf/azure/Application.xml
@@ -72,11 +72,10 @@
 			<VODTimedTextProviders></VODTimedTextProviders>
 			<!-- Properties for TimedText -->
 			<Properties>
-				<Property>
-					<Name>captionLiveIngestLanguages</Name>
-					<Value>en</Value>
-<!--					<Value>en,es,fr,de</Value>-->
-				</Property>
+<!--				<Property>-->
+<!--					<Name>captionLiveIngestLanguages</Name>-->
+<!--					<Value>eng,spa,fra,deu,por</Value>-->
+<!--				</Property>-->
 			</Properties>
 		</TimedText>
 		<!-- HTTPStreamers (separate with commas): cupertinostreaming, smoothstreaming, sanjosestreaming, mpegdashstreaming, dvrchunkstreaming -->
@@ -187,18 +186,6 @@
 		<LiveStreamPacketizer>
 			<!-- Properties defined here will override any properties defined in conf/LiveStreamPacketizers.xml for any LiveStreamPacketizers loaded by this applications -->
 			<Properties>
-				<Property>
-					<Name>cupertinoChunkDurationTarget</Name>
-					<Value>6000</Value>
-				</Property>
-				<Property>
-					<Name>cupertinoMaxChunkCount</Name>
-					<Value>10</Value>
-				</Property>
-				<Property>
-					<Name>cupertinoPlaylistChunkCount</Name>
-					<Value>6</Value>
-				</Property>
 			</Properties>
 		</LiveStreamPacketizer>
 		<HTTPStreamer>
@@ -247,7 +234,7 @@
 			</Property>
 			<Property>
 				<Name>captionHandlerDebug</Name>
-				<Value>true</Value>
+				<Value>false</Value>
 			</Property>
 			<Property>
 				<Name>captionHandlerStreamDelay</Name>

--- a/conf/whisper/Application.xml
+++ b/conf/whisper/Application.xml
@@ -72,10 +72,10 @@
 			<VODTimedTextProviders></VODTimedTextProviders>
 			<!-- Properties for TimedText -->
 			<Properties>
-				<Property>
-					<Name>captionLiveIngestLanguages</Name>
-					<Value>en</Value>
-				</Property>
+<!--				<Property>-->
+<!--					<Name>captionLiveIngestLanguages</Name>-->
+<!--					<Value>eng</Value>-->
+<!--				</Property>-->
 			</Properties>
 		</TimedText>
 		<!-- HTTPStreamers (separate with commas): cupertinostreaming, smoothstreaming, sanjosestreaming, mpegdashstreaming, dvrchunkstreaming -->
@@ -238,7 +238,7 @@
 			</Property>
 			<Property>
 				<Name>captionHandlerDebug</Name>
-				<Value>true</Value>
+				<Value>false</Value>
 			</Property>
 		</Properties>
 	</Application>

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
             - ADMIN_PASSWORD=password
             - IPWHITELIST=*
             - TRANSCODER=enabled #enabled | disabled | remove to not change
-            - LOG_LEVEL=WARN #DEBUG INFO WARN ERROR
+            - LOG_LEVEL=INFO #DEBUG INFO WARN ERROR
             - SIMU_LIVE=disabled
         volumes:
 #to persist the configurations between starts of Wowza Streaming Engine, uncomment the lines below:
@@ -20,7 +20,7 @@ services:
 #            - ./wse/logs:/usr/local/WowzaStreamingEngine/logs
 #            - ./wse/transcoder:/usr/local/WowzaStreamingEngine/transcoder
             - ./conf:/usr/local/WowzaStreamingEngine/conf.addon
-            - ./build/libs:/usr/local/WowzaStreamingEngine/lib.addon
+            - ./lib:/usr/local/WowzaStreamingEngine/lib.addon
         ports:
             - 8087:8087
             - 80:80
@@ -37,7 +37,7 @@ services:
             context: wowza_setup
         restart: "no"
         volumes:
-            - ./build/libs:/wowza_setup/downloads
+            - ./lib:/wowza_setup/downloads
 
     whisper_server:
         hostname: whisper.server

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
-name: Wowza Streaming Engine Trial
+name: Wowza Streaming Engine Caption Handlers
 services:
-    trial:
+    wse:
         hostname: wse.docker
         image: wowza/wowza-streaming-engine:latest-trial
         platform: linux/amd64

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,12 +20,12 @@ services:
 #            - ./wse/transcoder:/usr/local/WowzaStreamingEngine/transcoder
             - ./conf:/usr/local/WowzaStreamingEngine/conf.addon
             - ./build/libs:/usr/local/WowzaStreamingEngine/lib.addon
-            - ./src/main/resources/transcoder:/usr/local/WowzaStreamingEngine/transcoder.addon
         ports:
             - 8087:8087
             - 80:80
             - 443:443
             - 1935:1935
+
     whisper_server:
         hostname: whisper.server
         image: wowza/whisper_streaming:1.0.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,3 @@
 title = Wowza Caption Handlers
 projectName = caption-handlers
-version = 1.0.0
 #wseLibDir = /usr/local/WowzaStreamingEngine/lib

--- a/src/main/java/com/wowza/wms/plugin/captions/audio/SpeechHandler.java
+++ b/src/main/java/com/wowza/wms/plugin/captions/audio/SpeechHandler.java
@@ -5,8 +5,54 @@
 
 package com.wowza.wms.plugin.captions.audio;
 
+import java.util.Locale;
+import java.util.MissingResourceException;
+
 public interface SpeechHandler extends Runnable, AutoCloseable
 {
     void addAudioFrame(byte[] frame);
+
     void close();
+
+    default Locale toLocale(String input)
+    {
+        if (input == null || input.isBlank()) return null;
+        input = input.trim();
+
+        // Case 1: 2-letter ISO language code
+        if (input.length() == 2)
+            return new Locale(input.toLowerCase());
+
+        // Case 2: 3-letter ISO 639 code
+        if (input.length() == 3)
+        {
+            for (Locale l : Locale.getAvailableLocales())
+            {
+                try
+                {
+                    if (l.getISO3Language().equalsIgnoreCase(input))
+                        return new Locale(l.getLanguage());
+                } catch (MissingResourceException ignored) {}
+            }
+        }
+
+        // Case 3: Valid BCP 47 tag like "en-GB" or "zh-Hant-TW"
+        Locale tagLocale = Locale.forLanguageTag(input);
+        if (tagLocale.getLanguage().length() == 2)
+            return tagLocale;
+
+        // Otherwise, invalid input
+        return null;
+    }
+
+    default boolean isBCP47WithRegion(String tag)
+    {
+        if (tag == null || tag.isBlank()) return false;
+
+        Locale locale = Locale.forLanguageTag(tag);
+        String lang = locale.getLanguage();
+        String region = locale.getCountry();
+
+        return lang.length() == 2 && region.length() == 2;
+    }
 }

--- a/src/main/java/com/wowza/wms/plugin/captions/whisper/model/WhisperResponse.java
+++ b/src/main/java/com/wowza/wms/plugin/captions/whisper/model/WhisperResponse.java
@@ -7,13 +7,14 @@ package com.wowza.wms.plugin.captions.whisper.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.wowza.wms.timedtext.model.ITimedTextConstants;
+
+import java.util.Locale;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class WhisperResponse
 {
     @JsonProperty
-    private String language = ITimedTextConstants.LANGUAGE_ID_ENGLISH;
+    private String language = Locale.ENGLISH.getLanguage();
     @JsonProperty
     private String text;
     @JsonProperty

--- a/wowza_setup/setup_script.sh
+++ b/wowza_setup/setup_script.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
-if [ -f "/wowza_setup/downloads/wse-plugin-caption-handlers-1.0.0.jar" ]; then
-	echo "File wse-plugin-caption-handlers-1.0.0.jar exists"
+if [ -f "/wowza_setup/downloads/wse-plugin-caption-handlers-1.1.0.jar" ]; then
+	echo "File wse-plugin-caption-handlers-1.1.0.jar exists"
 else
-	echo "Getting wse-plugin-caption-handlers-1.0.0.jar"
-	wget -q -P /wowza_setup/downloads/ https://github.com/WowzaMediaSystems/wse-plugin-caption-handlers/releases/download/1.0.0/wse-plugin-caption-handlers-1.0.0.jar 
+	echo "Getting wse-plugin-caption-handlers-1.1.0.jar"
+	wget -q -P /wowza_setup/downloads/ https://github.com/WowzaMediaSystems/wse-plugin-caption-handlers/releases/download/1.1.0/wse-plugin-caption-handlers-1.1.0.jar
+	echo "Getting client-sdk-1.44.0.jar"
+	wget -q -P /wowza_setup/downloads/ https://github.com/WowzaMediaSystems/wse-plugin-caption-handlers/releases/download/1.1.0/client-sdk-1.44.0.jar
 fi


### PR DESCRIPTION
Change how the `audioResample.xml` template is loaded so it doesn't need to be copied to the file system.

Remap the transcoded output streams so the `_delayed` suffix is removed.

There has been some confusion with setting up the plugin to run standalone.  These changes hopefully resolve some of the confusion by automatically loading the audioResample template so it doesn't need to be copied to the templates folder, and then for any main transcodes, it automatically removes the `_delayed` suffix from the name.